### PR TITLE
Add benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Make sure you have these tools installed:
 - Node.js (18.0.0+)
 - Poetry (1.4.0+)
 
+Note: the project is only tested with python 3.11, and it is recommended to use the same version.
+
 ### 🔑 API keys setup
 
 Create a `.env.development` file in the project root:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -221,3 +221,49 @@ Common HTTP Status Codes
 - ``400 Bad Request``: Invalid parameters
 - ``422 Unprocessable Entity``: Invalid request body
 - ``500 Internal Server Error``: Server-side error
+
+
+API Benchmark
+-------------
+
+The following table shows latency benchmarks for the /recommend API endpoint. Tests were run with different combinations of query parameters and reranking options. Each request was made sequentially to measure individual request latency accurately.
+The summary statistics are generating from 50 runs with a timeout of 30 seconds w/ no delay between each request.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Test Case
+     - Mean (s)
+     - Median (s)
+     - Std Dev (s)
+     - Min (s)
+     - Max (s)
+     - Sample Size
+   * - Query only
+     - 6.686
+     - 5.985
+     - 2.336
+     - 4.504
+     - 19.362
+     - 48
+   * - Query w/ reranking
+     - 8.729
+     - 8.547
+     - 1.964
+     - 5.249
+     - 14.133
+     - 50
+   * - Query w/ location
+     - 6.795
+     - 6.260
+     - 3.560
+     - 3.277
+     - 27.860
+     - 46
+   * - Query w/ location and reranking
+     - 8.197
+     - 7.934
+     - 1.867
+     - 5.720
+     - 13.688
+     - 50

--- a/health_rec/services/rag.py
+++ b/health_rec/services/rag.py
@@ -38,10 +38,10 @@ class RAGService:
         """Filter services by location and radius."""
         filtered_services = []
         for service in services:
-            if service.metadata.get("Latitude") and service.metadata.get("Longitude"):
+            if service.metadata.get("latitude") and service.metadata.get("longitude"):
                 service_location = (
-                    float(service.metadata["Latitude"]),
-                    float(service.metadata["Longitude"]),
+                    float(service.metadata["latitude"]),
+                    float(service.metadata["longitude"]),
                 )
                 distance = _calculate_distance(service_location, location)
                 if distance <= radius:


### PR DESCRIPTION
# Documentation

# Short Description
- Add latency benchmarks of /recommend API for different configurations.
- Fix bug in rag.py to accept lowercase "latitutude"/"longitude" arguments in /recommend API.
- Add note in readme that python3.11 is the only tested version of python for the project.
